### PR TITLE
docs-output

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -19,6 +19,7 @@ lint:
     - .github/ISSUE_TEMPLATE/bug_report.yml
     - .github/workflows/linting.yml
     - assets/email_template.txt
+    - assets/email_template.html
     - docs/README.md
     - .prettierignore
   actions_ci: false

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -279,7 +279,7 @@ process {
                 memory = { check_max(50.GB * task.attempt, 'memory') }
                 ext.prefix = { "${meta.id}.qdnaseq" }
                 publishDir = [[
-                    enabled: true,
+                    enabled: !output_callers,
                     overwrite: true,
                     path: { "${params.outdir}/${meta.id}" },
                     mode: params.publish_dir_mode,
@@ -320,7 +320,7 @@ process {
                 memory = { check_max(50.GB * task.attempt, 'memory') }
                 ext.prefix = { "${meta.id}.wisecondorx" }
                 publishDir = [[
-                    enabled: true,
+                    enabled: !output_callers,
                     overwrite: true,
                     path: { "${params.outdir}/${meta.id}" },
                     mode: params.publish_dir_mode,
@@ -479,7 +479,7 @@ process {
 
         if(!params.annotations_filter) {
             withName: "^.*:VCF_ANNOTATE_VEP_ANNOTSV_VCFANNO:TABIX_ANNOTATED\$" {
-                ext.prefix = { "${meta.id}.${meta.variant_type}" }
+                ext.prefix = { "${meta.id}.${meta.variant_type}.annotated" }
                 publishDir = [
                     enabled: (count_types == 1 || !params.concat_output),
                     overwrite: true,
@@ -492,7 +492,7 @@ process {
 
         if(params.annotations_filter) {
             withName: "^.*:VCF_ANNOTATE_VEP_ANNOTSV_VCFANNO:BCFTOOLS_FILTER_COMMON\$" {
-                ext.prefix = {"${meta.id}.${meta.variant_type}"}
+                ext.prefix = {"${meta.id}.${meta.variant_type}.annotated"}
                 ext.args = "${params.annotations_filter} --output-type z"
                 publishDir = [
                     enabled: (count_types == 1 || !params.concat_output),
@@ -531,7 +531,7 @@ process {
 
         withName: "^.*:BAM_REPEAT_ESTIMATION_EXPANSIONHUNTER:BCFTOOLS_ANNOTATE\$" {
             ext.args = "-c INFO/REPREF:=INFO/REF --output-type z"
-            ext.prefix = { "${meta.id}.repeats" }
+            ext.prefix = { "${meta.id}.expansionhunter" }
             ext.tabix = true
             publishDir = [[
                 enabled: (count_types == 1 || !params.concat_output),

--- a/docs/output.md
+++ b/docs/output.md
@@ -4,16 +4,168 @@
 
 This document describes the output produced by the pipeline. Most of the plots are taken from the MultiQC report, which summarises results at the end of the pipeline.
 
-The directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
-
-<!-- TODO nf-core: Write this documentation describing your workflow's output -->
+The files and directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
 
 ## Pipeline overview
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
+- [SV calling](https://github.com/nf-cmgg/structural/blob/dev/subworkflows/local/bam_sv_calling/main.nf) - Merged set of structural variant (SV) calls for the selected SV callers
+- [CNV calling](https://github.com/nf-cmgg/structural/blob/dev/subworkflows/local/bam_cnv_calling/main.nf) - Merged set of copy number variant (CNV) calls for the selected CNV callers
+- [RRE calling](https://github.com/Illumina/ExpansionHunter) - Merged set of repeat region expansions (RRE) calls for the selected RRE callers
+- [SV annotation](https://github.com/nf-cmgg/structural/blob/dev/subworkflows/local/bam_sv_calling/main.nf) - Annotated set of structural variant (SV) calls for the selected SV callers
 - [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
 - [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
+
+### SV calling
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/sampleID.sv.vcf.gz`: vcf format file with merged SV calls for all selected callers.
+- `sampleID/sampleID.sv.vcf.gz`: tabix index for the vcf format file with merged SV calls for all selected callers.
+
+</details>
+
+SV calling runs all selected callers individually and merges the calls after. Optionally, the output of the selected callers can also be stored individually. SV calling provides the following callers:
+
+- [Delly](https://github.com/dellytools/delly)
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/delly/`
+  - `sampleID.delly.vcf.gz`: vcf format file with SV calls for Delly.
+ - `sampleID.delly.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Delly.
+  
+</details>
+
+[Delly](https://github.com/dellytools/delly) is an integrated structural variant (SV) prediction method that can discover, genotype and visualize deletions, tandem duplications, inversions and translocations at single-nucleotide resolution in short-read and long-read massively parallel sequencing data. It uses paired-ends, split-reads and read-depth to sensitively and accurately delineate genomic rearrangements throughout the genome.
+
+- [Manta](https://github.com/Illumina/manta)
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/manta/`
+  - `sampleID.manta.vcf.gz`: vcf format file with SV calls for Manta.
+ - `sampleID.manta.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Manta.
+
+ </details>
+
+ [Manta](https://github.com/Illumina/manta) calls structural variants (SVs) and indels from mapped paired-end sequencing reads. It is optimized for analysis of germline variation in small sets of individuals and somatic variation in tumor/normal sample pairs. Manta discovers, assembles and scores large-scale SVs, medium-sized indels and large insertions within a single efficient workflow. The method is designed for rapid analysis on standard compute hardware: NA12878 at 50x genomic coverage is analyzed in less than 20 minutes on a 20 core server, and most WGS tumor/normal analyses can be completed within 2 hours. Manta combines paired and split-read evidence during SV discovery and scoring to improve accuracy, but does not require split-reads or successful breakpoint assemblies to report a variant in cases where there is strong evidence otherwise. It provides scoring models for germline variants in small sets of diploid samples and somatic variants in matched tumor/normal sample pairs. There is experimental support for analysis of unmatched tumor samples as well. Manta accepts input read mappings from BAM or CRAM files and reports all SV and indel inferences in VCF 4.1 format. See the user guide for a full description of capabilities and limitations.
+  
+- [Smoove](https://github.com/brentp/smoove)
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/smoove/`
+  - `sampleID.smoove.vcf.gz`: vcf format file with SV calls for Smoove.
+ - `sampleID.smoove.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Smoove.
+
+ </details>
+
+ [Smoove](https://github.com/brentp/smoove) simplifies and speeds calling and genotyping SVs for short reads. It also improves specificity by removing many spurious alignment signals that are indicative of low-level noise and often contribute to spurious calls. It wraps existing software and adds some internal read-filtering to simplify calling and genotyping structural variants. It parallelizes each step as it can, for example, it streams lumpy output directly to multiple svtyper processes for genotyping. 
+
+### CNV calling
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/sampleID.cnv.vcf.gz`: vcf format file with merged CNV calls for all selected callers.
+- `sampleID/sampleID.cnv.vcf.gz`: tabix index for the vcf format file with merged CNV calls for all selected callers.
+
+</details>
+
+CNV calling runs all selected callers individually and merges the calls after. Optionally, the output of the selected callers can also be stored individually. If this option is not selected, than files that would normally appear in the callers' result directories are provided in the main results directory. CNV calling provides the following callers:
+
+- [WisecondorX](https://github.com/CenterForMedicalGeneticsGhent/WisecondorX)
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/wisecondorx/`
+ - `sampleID.wisecondorx.vcf.gz`: vcf format file with CNV calls for WisecondorX.
+ - `sampleID.wisecondorx.vcf.gz.tbi`: tabix index for the vcf format file with CNV calls for WisecondorX.
+ - `sampleID.wisecondorx_aberrations.bed`: bed format file with aberrant segments.
+ - `sampleID.wisecondorx_bins.bed`: bed format file with bin-wise information.
+ - `sampleID.wisecondorx_segments.bed`: bed format file with segment-wise information.
+ - `sampleID/chr1-X.png`: copy number profiles for every chromosome.
+ - `sampleID/genome_wide.png`: genome-wide copy number profiles.
+
+</details>
+
+After extensively comparing different (shallow) whole-genome sequencing-based copy number detection tools, including WISECONDOR, QDNAseq, CNVkit, Control-FREEC, BIC-seq2 and cn.MOPS, WISECONDOR appeared to normalize sequencing data in the most consistent way, as shown by our paper. Nevertheless, WISECONDOR has limitations: Stouffer's Z-score approach is error-prone when dealing with large amounts of aberrations, the algorithm is extremely slow (24h) when operating at small bin sizes (15 kb), and sex chromosomes are not part of the analysis. Here, we present WisecondorX, an evolved WISECONDOR that aims at dealing with previous difficulties, resulting in overall superior results and significantly lower computing times, allowing daily diagnostic use. WisecondorX is meant to be applicable not only to NIPT, but also gDNA, PGT, FFPE, LQB, ... etc.
+
+- [QDNAseq](https://github.com/ccagc/QDNAseq)
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/qdnaseq/`
+ - `sampleID.qdnaseq.abberations.bed`: bed format file with aberrant copy numbers.
+ - `sampleID.qdnaseq.bed`: bed format file with copy numbers.
+ - `sampleID.qdnaseq.cna`: file with bin-wise information.
+ - `sampleID.qdnaseq.vcf.gz`: vcf format file with CNV calls for QDNAseq.
+ - `sampleID.qdnaseq.vcf.gz.tbi`: tabix index for the vcf format file with CNV calls for QDNAseq.
+ - `sampleID.qdnaseq_segments.txt`: file with segment-wise information.
+ - `statistics.out`: statistics report. 
+  
+</details>
+
+Quantitative DNA sequencing for chromosomal aberrations. The genome is divided into non-overlapping fixed-sized bins, number of sequence reads in each counted, adjusted with a simultaneous two-dimensional loess correction for sequence mappability and GC content, and filtered to remove spurious regions in the genome. Downstream steps of segmentation and calling are also implemented via packages DNAcopy and CGHcall, respectively. 
+
+### RRE calling
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/sampleID.repeats.vcf.gz`: vcf format file with merged RRE calls for all selected callers.
+- `sampleID/sampleID.repeats.vcf.gz`: tabix index for the vcf format file with merged RRE calls for all selected callers.
+
+</details>
+
+RRE calling runs all selected callers individually and merges the calls after. Optionally, the output of the selected callers can also be stored individually. CNV calling provides the following callers:
+
+</details>
+
+- [ExpansionHunter](https://github.com/Illumina/ExpansionHunter)
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/sampleID.expansionhunter.vcf.gz`: vcf format file with RRE calls for ExpansionHunter.
+- `sampleID/sampleID.expansionhunter.vcf.gz`: tabix index for the vcf format file with RRE calls for ExpansionHunter.
+
+</details>
+
+There are a number of regions in the human genome consisting of repetitions of short unit sequence (commonly a trimer). Such repeat regions can expand to a size much larger than the read length and thereby cause a disease. Fragile X Syndrome, ALS, and Huntington's Disease are well known examples. [ExpansionHunter](https://github.com/Illumina/ExpansionHunter) aims to estimate sizes of such repeats by performing a targeted search through a BAM/CRAM file for reads that span, flank, and are fully contained in each repeat.
+
+### SV annotation
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `sampleID/sampleID.sv.vcf.gz`: vcf format file with merged and annotated SV calls for all selected callers.
+- `sampleID/sampleID.sv.vcf.gz`: tabix index for the vcf format file with merged and annotated SV calls for all selected callers.
+
+</details>
+
+SV annotation runs each annotation method individually and merges their output after. SV calling provides the following annotation methods:
+
+- [AnnotSV](https://github.com/lgmgeo/AnnotSV)
+
+</details>
+
+[AnnotSV](https://github.com/lgmgeo/AnnotSV)  is a program designed for annotating and ranking Structural Variations (SV). This tool compiles functionally, regulatory and clinically relevant information and aims at providing annotations useful to i. interpret SV potential pathogenicity and ii. filter out SV potential false positives. Different types of SV exist including deletions, duplications, insertions, inversions, translocations or more complex rearrangements. They can be either balanced or unbalanced. When unbalanced and resulting in a gain or loss of material, they are called Copy Number Variations (CNV). CNV can be described by coordinates on one chromosome, with the start and end positions of the SV (deletions, insertions, duplications).Complex rearrangements with several breakends can arbitrary be summarized as a set of novel adjacencies, as described
+in the Variant Call Format specification VCFv4.3.
+
+- [ensembl VEP](https://www.ensembl.org/info/docs/tools/vep/index.html)
+
+</details>
+
+[ensembl VEP](https://www.ensembl.org/info/docs/tools/vep/index.html) determines the effect of your variants (SNPs, insertions, deletions, CNVs or structural variants) on genes, transcripts, and protein sequence, as well as regulatory regions. 
 
 ### MultiQC
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -10,10 +10,10 @@ The files and directories listed below will be created in the results directory 
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
-- [SV calling](https://github.com/nf-cmgg/structural/blob/dev/subworkflows/local/bam_sv_calling/main.nf) - Merged set of structural variant (SV) calls for the selected SV callers
-- [CNV calling](https://github.com/nf-cmgg/structural/blob/dev/subworkflows/local/bam_cnv_calling/main.nf) - Merged set of copy number variant (CNV) calls for the selected CNV callers
-- [RRE calling](https://github.com/Illumina/ExpansionHunter) - Merged set of repeat region expansions (RRE) calls for the selected RRE callers
-- [SV annotation](https://github.com/nf-cmgg/structural/blob/dev/subworkflows/local/bam_sv_calling/main.nf) - Annotated set of structural variant (SV) calls for the selected SV callers
+- [SV calling](#sv-calling) - Merged set of structural variant (SV) calls for the selected SV callers
+- [CNV calling](#cnv-calling) - Merged set of copy number variant (CNV) calls for the selected CNV callers
+- [RRE calling](#rre-calling) - Merged set of repeat region expansions (RRE) calls for the selected RRE callers
+- [SV annotation](#sv-annotation) - Annotated set of structural variant (SV) calls for the selected SV callers
 - [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
 - [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -23,7 +23,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 <summary>Output files</summary>
 
 - `sampleID/sampleID.sv.vcf.gz`: vcf format file with merged SV calls for all selected callers.
-- `sampleID/sampleID.sv.vcf.gz`: tabix index for the vcf format file with merged SV calls for all selected callers.
+- `sampleID/sampleID.sv.vcf.gz.tbi`: tabix index for the vcf format file with merged SV calls for all selected callers.
 
 </details>
 
@@ -36,8 +36,8 @@ SV calling runs all selected callers individually and merges the calls after. Op
 
 - `sampleID/delly/`
   - `sampleID.delly.vcf.gz`: vcf format file with SV calls for Delly.
- - `sampleID.delly.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Delly.
-  
+- `sampleID.delly.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Delly.
+
 </details>
 
 [Delly](https://github.com/dellytools/delly) is an integrated structural variant (SV) prediction method that can discover, genotype and visualize deletions, tandem duplications, inversions and translocations at single-nucleotide resolution in short-read and long-read massively parallel sequencing data. It uses paired-ends, split-reads and read-depth to sensitively and accurately delineate genomic rearrangements throughout the genome.
@@ -49,12 +49,12 @@ SV calling runs all selected callers individually and merges the calls after. Op
 
 - `sampleID/manta/`
   - `sampleID.manta.vcf.gz`: vcf format file with SV calls for Manta.
- - `sampleID.manta.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Manta.
+- `sampleID.manta.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Manta.
 
  </details>
 
- [Manta](https://github.com/Illumina/manta) calls structural variants (SVs) and indels from mapped paired-end sequencing reads. It is optimized for analysis of germline variation in small sets of individuals and somatic variation in tumor/normal sample pairs. Manta discovers, assembles and scores large-scale SVs, medium-sized indels and large insertions within a single efficient workflow. The method is designed for rapid analysis on standard compute hardware: NA12878 at 50x genomic coverage is analyzed in less than 20 minutes on a 20 core server, and most WGS tumor/normal analyses can be completed within 2 hours. Manta combines paired and split-read evidence during SV discovery and scoring to improve accuracy, but does not require split-reads or successful breakpoint assemblies to report a variant in cases where there is strong evidence otherwise. It provides scoring models for germline variants in small sets of diploid samples and somatic variants in matched tumor/normal sample pairs. There is experimental support for analysis of unmatched tumor samples as well. Manta accepts input read mappings from BAM or CRAM files and reports all SV and indel inferences in VCF 4.1 format. See the user guide for a full description of capabilities and limitations.
-  
+[Manta](https://github.com/Illumina/manta) calls structural variants (SVs) and indels from mapped paired-end sequencing reads. It is optimized for analysis of germline variation in small sets of individuals and somatic variation in tumor/normal sample pairs. Manta discovers, assembles and scores large-scale SVs, medium-sized indels and large insertions within a single efficient workflow. The method is designed for rapid analysis on standard compute hardware: NA12878 at 50x genomic coverage is analyzed in less than 20 minutes on a 20 core server, and most WGS tumor/normal analyses can be completed within 2 hours. Manta combines paired and split-read evidence during SV discovery and scoring to improve accuracy, but does not require split-reads or successful breakpoint assemblies to report a variant in cases where there is strong evidence otherwise. It provides scoring models for germline variants in small sets of diploid samples and somatic variants in matched tumor/normal sample pairs. There is experimental support for analysis of unmatched tumor samples as well. Manta accepts input read mappings from BAM or CRAM files and reports all SV and indel inferences in VCF 4.1 format. See the user guide for a full description of capabilities and limitations.
+
 - [Smoove](https://github.com/brentp/smoove)
 
 <details markdown="1">
@@ -62,11 +62,11 @@ SV calling runs all selected callers individually and merges the calls after. Op
 
 - `sampleID/smoove/`
   - `sampleID.smoove.vcf.gz`: vcf format file with SV calls for Smoove.
- - `sampleID.smoove.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Smoove.
+- `sampleID.smoove.vcf.gz.tbi`: tabix index for the vcf format file with SV calls for Smoove.
 
  </details>
 
- [Smoove](https://github.com/brentp/smoove) simplifies and speeds calling and genotyping SVs for short reads. It also improves specificity by removing many spurious alignment signals that are indicative of low-level noise and often contribute to spurious calls. It wraps existing software and adds some internal read-filtering to simplify calling and genotyping structural variants. It parallelizes each step as it can, for example, it streams lumpy output directly to multiple svtyper processes for genotyping. 
+[Smoove](https://github.com/brentp/smoove) simplifies and speeds calling and genotyping SVs for short reads. It also improves specificity by removing many spurious alignment signals that are indicative of low-level noise and often contribute to spurious calls. It wraps existing software and adds some internal read-filtering to simplify calling and genotyping structural variants. It parallelizes each step as it can, for example, it streams lumpy output directly to multiple svtyper processes for genotyping.
 
 ### CNV calling
 
@@ -74,7 +74,7 @@ SV calling runs all selected callers individually and merges the calls after. Op
 <summary>Output files</summary>
 
 - `sampleID/sampleID.cnv.vcf.gz`: vcf format file with merged CNV calls for all selected callers.
-- `sampleID/sampleID.cnv.vcf.gz`: tabix index for the vcf format file with merged CNV calls for all selected callers.
+- `sampleID/sampleID.cnv.vcf.gz.tbi`: tabix index for the vcf format file with merged CNV calls for all selected callers.
 
 </details>
 
@@ -86,13 +86,13 @@ CNV calling runs all selected callers individually and merges the calls after. O
 <summary>Output files</summary>
 
 - `sampleID/wisecondorx/`
- - `sampleID.wisecondorx.vcf.gz`: vcf format file with CNV calls for WisecondorX.
- - `sampleID.wisecondorx.vcf.gz.tbi`: tabix index for the vcf format file with CNV calls for WisecondorX.
- - `sampleID.wisecondorx_aberrations.bed`: bed format file with aberrant segments.
- - `sampleID.wisecondorx_bins.bed`: bed format file with bin-wise information.
- - `sampleID.wisecondorx_segments.bed`: bed format file with segment-wise information.
- - `sampleID/chr1-X.png`: copy number profiles for every chromosome.
- - `sampleID/genome_wide.png`: genome-wide copy number profiles.
+- `sampleID.wisecondorx.vcf.gz`: vcf format file with CNV calls for WisecondorX.
+- `sampleID.wisecondorx.vcf.gz.tbi`: tabix index for the vcf format file with CNV calls for WisecondorX.
+- `sampleID.wisecondorx_aberrations.bed`: bed format file with aberrant segments.
+- `sampleID.wisecondorx_bins.bed`: bed format file with bin-wise information.
+- `sampleID.wisecondorx_segments.bed`: bed format file with segment-wise information.
+- `sampleID/chr1-X.png`: copy number profiles for every chromosome.
+- `sampleID/genome_wide.png`: genome-wide copy number profiles.
 
 </details>
 
@@ -104,17 +104,17 @@ After extensively comparing different (shallow) whole-genome sequencing-based co
 <summary>Output files</summary>
 
 - `sampleID/qdnaseq/`
- - `sampleID.qdnaseq.abberations.bed`: bed format file with aberrant copy numbers.
- - `sampleID.qdnaseq.bed`: bed format file with copy numbers.
- - `sampleID.qdnaseq.cna`: file with bin-wise information.
- - `sampleID.qdnaseq.vcf.gz`: vcf format file with CNV calls for QDNAseq.
- - `sampleID.qdnaseq.vcf.gz.tbi`: tabix index for the vcf format file with CNV calls for QDNAseq.
- - `sampleID.qdnaseq_segments.txt`: file with segment-wise information.
- - `statistics.out`: statistics report. 
-  
+- `sampleID.qdnaseq.abberations.bed`: bed format file with aberrant copy numbers.
+- `sampleID.qdnaseq.bed`: bed format file with copy numbers.
+- `sampleID.qdnaseq.cna`: file with bin-wise information.
+- `sampleID.qdnaseq.vcf.gz`: vcf format file with CNV calls for QDNAseq.
+- `sampleID.qdnaseq.vcf.gz.tbi`: tabix index for the vcf format file with CNV calls for QDNAseq.
+- `sampleID.qdnaseq_segments.txt`: file with segment-wise information.
+- `statistics.out`: statistics report.
+
 </details>
 
-Quantitative DNA sequencing for chromosomal aberrations. The genome is divided into non-overlapping fixed-sized bins, number of sequence reads in each counted, adjusted with a simultaneous two-dimensional loess correction for sequence mappability and GC content, and filtered to remove spurious regions in the genome. Downstream steps of segmentation and calling are also implemented via packages DNAcopy and CGHcall, respectively. 
+Quantitative DNA sequencing for chromosomal aberrations. The genome is divided into non-overlapping fixed-sized bins, number of sequence reads in each counted, adjusted with a simultaneous two-dimensional loess correction for sequence mappability and GC content, and filtered to remove spurious regions in the genome. Downstream steps of segmentation and calling are also implemented via packages DNAcopy and CGHcall, respectively.
 
 ### RRE calling
 
@@ -122,7 +122,7 @@ Quantitative DNA sequencing for chromosomal aberrations. The genome is divided i
 <summary>Output files</summary>
 
 - `sampleID/sampleID.repeats.vcf.gz`: vcf format file with merged RRE calls for all selected callers.
-- `sampleID/sampleID.repeats.vcf.gz`: tabix index for the vcf format file with merged RRE calls for all selected callers.
+- `sampleID/sampleID.repeats.vcf.gz.tbi`: tabix index for the vcf format file with merged RRE calls for all selected callers.
 
 </details>
 
@@ -136,7 +136,7 @@ RRE calling runs all selected callers individually and merges the calls after. O
 <summary>Output files</summary>
 
 - `sampleID/sampleID.expansionhunter.vcf.gz`: vcf format file with RRE calls for ExpansionHunter.
-- `sampleID/sampleID.expansionhunter.vcf.gz`: tabix index for the vcf format file with RRE calls for ExpansionHunter.
+- `sampleID/sampleID.expansionhunter.vcf.gz.tbi`: tabix index for the vcf format file with RRE calls for ExpansionHunter.
 
 </details>
 
@@ -147,8 +147,8 @@ There are a number of regions in the human genome consisting of repetitions of s
 <details markdown="1">
 <summary>Output files</summary>
 
-- `sampleID/sampleID.sv.vcf.gz`: vcf format file with merged and annotated SV calls for all selected callers.
-- `sampleID/sampleID.sv.vcf.gz`: tabix index for the vcf format file with merged and annotated SV calls for all selected callers.
+- `sampleID/sampleID.sv.annotated.vcf.gz`: vcf format file with merged and annotated SV calls for all selected callers.
+- `sampleID/sampleID.sv.annotated.vcf.gz.tbi`: tabix index for the vcf format file with merged and annotated SV calls for all selected callers.
 
 </details>
 
@@ -158,14 +158,14 @@ SV annotation runs each annotation method individually and merges their output a
 
 </details>
 
-[AnnotSV](https://github.com/lgmgeo/AnnotSV)  is a program designed for annotating and ranking Structural Variations (SV). This tool compiles functionally, regulatory and clinically relevant information and aims at providing annotations useful to i. interpret SV potential pathogenicity and ii. filter out SV potential false positives. Different types of SV exist including deletions, duplications, insertions, inversions, translocations or more complex rearrangements. They can be either balanced or unbalanced. When unbalanced and resulting in a gain or loss of material, they are called Copy Number Variations (CNV). CNV can be described by coordinates on one chromosome, with the start and end positions of the SV (deletions, insertions, duplications).Complex rearrangements with several breakends can arbitrary be summarized as a set of novel adjacencies, as described
+[AnnotSV](https://github.com/lgmgeo/AnnotSV) is a program designed for annotating and ranking Structural Variations (SV). This tool compiles functionally, regulatory and clinically relevant information and aims at providing annotations useful to i. interpret SV potential pathogenicity and ii. filter out SV potential false positives. Different types of SV exist including deletions, duplications, insertions, inversions, translocations or more complex rearrangements. They can be either balanced or unbalanced. When unbalanced and resulting in a gain or loss of material, they are called Copy Number Variations (CNV). CNV can be described by coordinates on one chromosome, with the start and end positions of the SV (deletions, insertions, duplications).Complex rearrangements with several breakends can arbitrary be summarized as a set of novel adjacencies, as described
 in the Variant Call Format specification VCFv4.3.
 
 - [ensembl VEP](https://www.ensembl.org/info/docs/tools/vep/index.html)
 
 </details>
 
-[ensembl VEP](https://www.ensembl.org/info/docs/tools/vep/index.html) determines the effect of your variants (SNPs, insertions, deletions, CNVs or structural variants) on genes, transcripts, and protein sequence, as well as regulatory regions. 
+[ensembl VEP](https://www.ensembl.org/info/docs/tools/vep/index.html) determines the effect of your variants (SNPs, insertions, deletions, CNVs or structural variants) on genes, transcripts, and protein sequence, as well as regulatory regions.
 
 ### MultiQC
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,4 +1,4 @@
-# Parameters
+# nf-cmgg/structural pipeline parameters
 
 A nextflow pipeline for calling structural variants
 
@@ -6,151 +6,151 @@ A nextflow pipeline for calling structural variants
 
 Define where the pipeline should find input data and save output data.
 
-| Parameter       | Description                                                                                                                                                                                                                                                                                                                                                                                  | Type     | Default | Required | Hidden |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | -------- | ------ |
-| `input`         | Path to comma-separated file containing information about the samples in the experiment. <details><summary>Help</summary><small>You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.</small></details> | `string` |         | True     |        |
-| `outdir`        | The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.                                                                                                                                                                                                                                                                     | `string` |         | True     |        |
-| `email`         | Email address for completion summary. <details><summary>Help</summary><small>Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.</small></details>                                  | `string` |         |          |        |
-| `multiqc_title` | MultiQC report title. Printed as page header, used for filename if not otherwise specified.                                                                                                                                                                                                                                                                                                  | `string` |         |          |        |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `input` | Path to comma-separated file containing information about the samples in the experiment. <details><summary>Help</summary><small>You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.</small></details>| `string` |  | True |  |
+| `outdir` | The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure. | `string` |  | True |  |
+| `email` | Email address for completion summary. <details><summary>Help</summary><small>Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.</small></details>| `string` |  |  |  |
+| `multiqc_title` | MultiQC report title. Printed as page header, used for filename if not otherwise specified. | `string` |  |  |  |
 
 ## Reference genome options
 
 Reference genome related files and options required for the workflow.
 
-| Parameter                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                   | Type      | Default | Required | Hidden |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- | -------- | ------ |
-| `genome`                  | Name of iGenomes reference. <details><summary>Help</summary><small>If using a reference genome configured in the pipeline using iGenomes, use this parameter to give the ID for the reference. This is then used to build the full paths for all required reference genome files e.g. `--genome GRCh38`. <br><br>See the [nf-core website docs](https://nf-co.re/usage/reference_genomes) for more details.</small></details> | `string`  |         |          |        |
-| `fasta`                   | Path to FASTA genome file. <details><summary>Help</summary><small>This parameter is _mandatory_ if `--genome` is not specified. </small></details>                                                                                                                                                                                                                                                                            | `string`  |         |          |        |
-| `fai`                     | The index of the FASTA reference file                                                                                                                                                                                                                                                                                                                                                                                         | `string`  |         |          |        |
-| `bwa`                     | Path to the BWA index folder                                                                                                                                                                                                                                                                                                                                                                                                  | `string`  |         |          |        |
-| `expansionhunter_catalog` | Path to the expansionhunter catalog                                                                                                                                                                                                                                                                                                                                                                                           | `string`  |         |          |        |
-| `qdnaseq_male`            | Path to the male qdnaseq reference file                                                                                                                                                                                                                                                                                                                                                                                       | `string`  |         |          |        |
-| `qdnaseq_female`          | Path to the female qdnaseq reference file                                                                                                                                                                                                                                                                                                                                                                                     | `string`  |         |          |        |
-| `wisecondorx_reference`   | Path to the wisecondorx reference file                                                                                                                                                                                                                                                                                                                                                                                        | `string`  |         |          |        |
-| `blacklist`               | Path to the blacklist file                                                                                                                                                                                                                                                                                                                                                                                                    | `string`  |         |          |        |
-| `igenomes_ignore`         | Do not load the iGenomes reference config. <details><summary>Help</summary><small>Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`.</small></details>                                                                                                                                             | `boolean` |         |          | True   |
-| `genomes_base`            | The base path where the references can be found                                                                                                                                                                                                                                                                                                                                                                               | `string`  |         |          |        |
-| `genomes_ignore`          | Whether or not to use the references found in the `--genomes_base` folder                                                                                                                                                                                                                                                                                                                                                     | `boolean` |         |          |        |
-| `cmgg_config_base`        | The config base path for the cmgg configs                                                                                                                                                                                                                                                                                                                                                                                     | `string`  | /conf/  |          |        |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `genome` | Name of iGenomes reference. <details><summary>Help</summary><small>If using a reference genome configured in the pipeline using iGenomes, use this parameter to give the ID for the reference. This is then used to build the full paths for all required reference genome files e.g. `--genome GRCh38`. <br><br>See the [nf-core website docs](https://nf-co.re/usage/reference_genomes) for more details.</small></details>| `string` |  |  |  |
+| `fasta` | Path to FASTA genome file. <details><summary>Help</summary><small>This parameter is *mandatory* if `--genome` is not specified. </small></details>| `string` |  |  |  |
+| `fai` | The index of the FASTA reference file | `string` |  |  |  |
+| `bwa` | Path to the BWA index folder | `string` |  |  |  |
+| `expansionhunter_catalog` | Path to the expansionhunter catalog | `string` |  |  |  |
+| `qdnaseq_male` | Path to the male qdnaseq reference file | `string` |  |  |  |
+| `qdnaseq_female` | Path to the female qdnaseq reference file | `string` |  |  |  |
+| `wisecondorx_reference` | Path to the wisecondorx reference file | `string` |  |  |  |
+| `blacklist` | Path to the blacklist file | `string` |  |  |  |
+| `igenomes_ignore` | Do not load the iGenomes reference config. <details><summary>Help</summary><small>Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`.</small></details>| `boolean` |  |  | True |
+| `genomes_base` | The base path where the references can be found | `string` |  |  |  |
+| `genomes_ignore` | Whether or not to use the references found in the `--genomes_base` folder | `boolean` |  |  |  |
+| `cmgg_config_base` | The config base path for the cmgg configs | `string` | /conf/ |  |  |
 
 ## Institutional config options
 
 Parameters used to describe centralised config profiles. These should not be edited.
 
-| Parameter                    | Description                                                                                                                                                                                                                                                                                                                                                                                       | Type     | Default                                                  | Required | Hidden |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------- | -------- | ------ |
-| `custom_config_version`      | Git commit id for Institutional configs.                                                                                                                                                                                                                                                                                                                                                          | `string` | master                                                   |          | True   |
-| `custom_config_base`         | Base directory for Institutional configs. <details><summary>Help</summary><small>If you're running offline, Nextflow will not be able to fetch the institutional config files from the internet. If you don't need them, then this is not a problem. If you do need them, you should download the files from the repo and tell Nextflow where to find them with this parameter.</small></details> | `string` | https://raw.githubusercontent.com/nf-core/configs/master |          | True   |
-| `config_profile_name`        | Institutional config name.                                                                                                                                                                                                                                                                                                                                                                        | `string` |                                                          |          | True   |
-| `config_profile_description` | Institutional config description.                                                                                                                                                                                                                                                                                                                                                                 | `string` |                                                          |          | True   |
-| `config_profile_contact`     | Institutional config contact information.                                                                                                                                                                                                                                                                                                                                                         | `string` |                                                          |          | True   |
-| `config_profile_url`         | Institutional config URL link.                                                                                                                                                                                                                                                                                                                                                                    | `string` |                                                          |          | True   |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `custom_config_version` | Git commit id for Institutional configs. | `string` | master |  | True |
+| `custom_config_base` | Base directory for Institutional configs. <details><summary>Help</summary><small>If you're running offline, Nextflow will not be able to fetch the institutional config files from the internet. If you don't need them, then this is not a problem. If you do need them, you should download the files from the repo and tell Nextflow where to find them with this parameter.</small></details>| `string` | https://raw.githubusercontent.com/nf-core/configs/master |  | True |
+| `config_profile_name` | Institutional config name. | `string` |  |  | True |
+| `config_profile_description` | Institutional config description. | `string` |  |  | True |
+| `config_profile_contact` | Institutional config contact information. | `string` |  |  | True |
+| `config_profile_url` | Institutional config URL link. | `string` |  |  | True |
 
 ## Max job request options
 
 Set the top limit for requested resources for any single job.
 
-| Parameter    | Description                                                                                                                                                                                                                                                                 | Type      | Default | Required | Hidden |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- | -------- | ------ |
-| `max_cpus`   | Maximum number of CPUs that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the CPU requirement for each process. Should be an integer e.g. `--max_cpus 1`</small></details>                                      | `integer` | 16      |          | True   |
-| `max_memory` | Maximum amount of memory that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the memory requirement for each process. Should be a string in the format integer-unit e.g. `--max_memory '8.GB'`</small></details> | `string`  | 128.GB  |          | True   |
-| `max_time`   | Maximum amount of time that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the time requirement for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`</small></details>        | `string`  | 240.h   |          | True   |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `max_cpus` | Maximum number of CPUs that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the CPU requirement for each process. Should be an integer e.g. `--max_cpus 1`</small></details>| `integer` | 16 |  | True |
+| `max_memory` | Maximum amount of memory that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the memory requirement for each process. Should be a string in the format integer-unit e.g. `--max_memory '8.GB'`</small></details>| `string` | 128.GB |  | True |
+| `max_time` | Maximum amount of time that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the time requirement for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`</small></details>| `string` | 240.h |  | True |
 
 ## Generic options
 
 Less common options for the pipeline, typically set in a config file.
 
-| Parameter                          | Description                                                                                                                                                                                                                                                                                                                                                                                                  | Type      | Default | Required | Hidden |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ------- | -------- | ------ |
-| `help`                             | Display help text.                                                                                                                                                                                                                                                                                                                                                                                           | `boolean` |         |          | True   |
-| `version`                          | Display version and exit.                                                                                                                                                                                                                                                                                                                                                                                    | `boolean` |         |          | True   |
-| `publish_dir_mode`                 | Method used to save pipeline results to output directory. <details><summary>Help</summary><small>The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.</small></details> | `string`  | copy    |          | True   |
-| `email_on_fail`                    | Email address for completion summary, only when pipeline fails. <details><summary>Help</summary><small>An email address to send a summary email to when the pipeline is completed - ONLY sent if the pipeline does not exit successfully.</small></details>                                                                                                                                                  | `string`  |         |          | True   |
-| `plaintext_email`                  | Send plain-text email instead of HTML.                                                                                                                                                                                                                                                                                                                                                                       | `boolean` |         |          | True   |
-| `max_multiqc_email_size`           | File size limit when attaching MultiQC reports to summary emails.                                                                                                                                                                                                                                                                                                                                            | `string`  | 25.MB   |          | True   |
-| `monochromeLogs`                   | Do not use coloured log outputs.                                                                                                                                                                                                                                                                                                                                                                             | `boolean` |         |          | True   |
-| `hook_url`                         | Incoming hook URL for messaging service <details><summary>Help</summary><small>Incoming hook URL for messaging service. Currently, MS Teams and Slack are supported.</small></details>                                                                                                                                                                                                                       | `string`  |         |          | True   |
-| `multiqc_config`                   | Custom config file to supply to MultiQC.                                                                                                                                                                                                                                                                                                                                                                     | `string`  |         |          | True   |
-| `multiqc_logo`                     | Custom logo file to supply to MultiQC. File name must also be set in the MultiQC config file                                                                                                                                                                                                                                                                                                                 | `string`  |         |          | True   |
-| `multiqc_methods_description`      | Custom MultiQC yaml file containing HTML including a methods description.                                                                                                                                                                                                                                                                                                                                    | `string`  |         |          |        |
-| `validate_params`                  | Boolean whether to validate parameters against the schema at runtime                                                                                                                                                                                                                                                                                                                                         | `boolean` | True    |          | True   |
-| `validationShowHiddenParams`       | Show all params when using `--help` <details><summary>Help</summary><small>By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters.</small></details>                                                                                                                    | `boolean` |         |          | True   |
-| `validationFailUnrecognisedParams` | Validation of parameters fails when an unrecognised parameter is found. <details><summary>Help</summary><small>By default, when an unrecognised parameter is found, it returns a warinig.</small></details>                                                                                                                                                                                                  | `boolean` |         |          | True   |
-| `validationLenientMode`            | Validation of parameters in lenient more. <details><summary>Help</summary><small>Allows string values that are parseable as numbers or booleans. For further information see [JSONSchema docs](https://github.com/everit-org/json-schema#lenient-mode).</small></details>                                                                                                                                    | `boolean` |         |          | True   |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `help` | Display help text. | `boolean` |  |  | True |
+| `version` | Display version and exit. | `boolean` |  |  | True |
+| `publish_dir_mode` | Method used to save pipeline results to output directory. <details><summary>Help</summary><small>The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.</small></details>| `string` | copy |  | True |
+| `email_on_fail` | Email address for completion summary, only when pipeline fails. <details><summary>Help</summary><small>An email address to send a summary email to when the pipeline is completed - ONLY sent if the pipeline does not exit successfully.</small></details>| `string` |  |  | True |
+| `plaintext_email` | Send plain-text email instead of HTML. | `boolean` |  |  | True |
+| `max_multiqc_email_size` | File size limit when attaching MultiQC reports to summary emails. | `string` | 25.MB |  | True |
+| `monochromeLogs` | Do not use coloured log outputs. | `boolean` |  |  | True |
+| `hook_url` | Incoming hook URL for messaging service <details><summary>Help</summary><small>Incoming hook URL for messaging service. Currently, MS Teams and Slack are supported.</small></details>| `string` |  |  | True |
+| `multiqc_config` | Custom config file to supply to MultiQC. | `string` |  |  | True |
+| `multiqc_logo` | Custom logo file to supply to MultiQC. File name must also be set in the MultiQC config file | `string` |  |  | True |
+| `multiqc_methods_description` | Custom MultiQC yaml file containing HTML including a methods description. | `string` |  |  |  |
+| `validate_params` | Boolean whether to validate parameters against the schema at runtime | `boolean` | True |  | True |
+| `validationShowHiddenParams` | Show all params when using `--help` <details><summary>Help</summary><small>By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters.</small></details>| `boolean` |  |  | True |
+| `validationFailUnrecognisedParams` | Validation of parameters fails when an unrecognised parameter is found. <details><summary>Help</summary><small>By default, when an unrecognised parameter is found, it returns a warinig.</small></details>| `boolean` |  |  | True |
+| `validationLenientMode` | Validation of parameters in lenient more. <details><summary>Help</summary><small>Allows string values that are parseable as numbers or booleans. For further information see [JSONSchema docs](https://github.com/everit-org/json-schema#lenient-mode).</small></details>| `boolean` |  |  | True |
 
 ## Pipeline specific options
 
 Options specific to the execution of this pipeline
 
-| Parameter             | Description                                                                                                                                                                                     | Type      | Default | Required | Hidden                                                                                                                              |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------- | ---- | --- |
-| `callers`             | A comma-seperated list of callers to use. Can be one or more these: smoove                                                                                                                      | delly     | manta   | gridss   | expansionhunter. At the moment Gridss runs very slowly compared to all other tools so it's only advised to use it when it's needed. | `string` | manta,smoove,delly,expansionhunter,wisecondorx | True |     |
-| `output_callers`      | Output the VCF files from different callers. Warning: This produces a lot of additional output and should only be used for testing purposes                                                     | `boolean` |         |          |                                                                                                                                     |
-| `sv_callers_support`  | The minimum amount of SV callers that should detect a variant. All variants that have a lower amount of callers supporting it, will be removed. (Only used when more than one caller is given)  | `integer` | 1       |          |                                                                                                                                     |
-| `cnv_callers_support` | The minimum amount of CNV callers that should detect a variant. All variants that have a lower amount of callers supporting it, will be removed. (Only used when more than one caller is given) | `integer` | 1       |          |                                                                                                                                     |
-| `annotate`            | Runs the annotation with Ensembl VEP when true                                                                                                                                                  | `boolean` |         |          |                                                                                                                                     |
-| `concat_output`       | Also output a concatenated VCF with all types analysed included (with the exception of CNVs)                                                                                                    | `boolean` |         |          |                                                                                                                                     |
-| `annotations_filter`  | The filter arguments to use after annotating. e.g. to filter out common variants.                                                                                                               | `string`  |         |          |                                                                                                                                     |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `callers` | A comma-seperated list of callers to use. Can be one or more these: smoove|delly|manta|gridss|expansionhunter. At the moment Gridss runs very slowly compared to all other tools so it's only advised to use it when it's needed. | `string` | manta,smoove,delly,expansionhunter,wisecondorx | True |  |
+| `output_callers` | Output the VCF files from different callers. Warning: This produces a lot of additional output and should only be used for testing purposes | `boolean` |  |  |  |
+| `sv_callers_support` | The minimum amount of SV callers that should detect a variant. All variants that have a lower amount of callers supporting it, will be removed. (Only used when more than one caller is given) | `integer` | 1 |  |  |
+| `cnv_callers_support` | The minimum amount of CNV callers that should detect a variant. All variants that have a lower amount of callers supporting it, will be removed. (Only used when more than one caller is given) | `integer` | 1 |  |  |
+| `annotate` | Runs the annotation with Ensembl VEP when true | `boolean` |  |  |  |
+| `concat_output` | Also output a concatenated VCF with all types analysed included (with the exception of CNVs) | `boolean` |  |  |  |
+| `annotations_filter` | The filter arguments to use after annotating. e.g. to filter out common variants. | `string` |  |  |  |
 
 ## Delly parameters
 
 Options specific for the Delly execution
 
-| Parameter               | Description                                                   | Type      | Default | Required | Hidden |
-| ----------------------- | ------------------------------------------------------------- | --------- | ------- | -------- | ------ |
-| `delly_sv_types`        | Which SV types delly should search for in the variant calling | `string`  | ALL     |          |        |
-| `delly_map_qual`        | The mapping quality to use for delly                          | `integer` | 1       |          |        |
-| `delly_min_clique_size` | The minimum clique size to use for delly                      | `integer` | 2       |          |        |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `delly_sv_types` | Which SV types delly should search for in the variant calling | `string` | ALL |  |  |
+| `delly_map_qual` | The mapping quality to use for delly | `integer` | 1 |  |  |
+| `delly_min_clique_size` | The minimum clique size to use for delly | `integer` | 2 |  |  |
 
 ## Manta parameters
 
 Options specific for the Manta execution
 
-| Parameter      | Description                      | Type     | Default | Required | Hidden |
-| -------------- | -------------------------------- | -------- | ------- | -------- | ------ |
-| `manta_config` | A config file to supply to manta | `string` |         |          |        |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `manta_config` | A config file to supply to manta | `string` |  |  |  |
 
 ## qDNAseq parameters
 
 Options specific for the qDNAseq execution
 
-| Parameter           | Description                                                                      | Type      | Default | Required | Hidden |
-| ------------------- | -------------------------------------------------------------------------------- | --------- | ------- | -------- | ------ |
-| `qdnaseq_bin_size`  | The bin size to use for qdnaseq                                                  | `integer` | 100000  |          |        |
-| `qdnaseq_cnv_ratio` | The minimum value of the absolute cnv ratio for a variant to be considered a CNV | `number`  | 0.5     |          |        |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `qdnaseq_bin_size` | The bin size to use for qdnaseq | `integer` | 100000 |  |  |
+| `qdnaseq_cnv_ratio` | The minimum value of the absolute cnv ratio for a variant to be considered a CNV | `number` | 0.5 |  |  |
 
 ## VEP options
 
 Options for the annotation with VEP
 
-| Parameter           | Description                                                                                                                                                                                                                                                             | Type      | Default      | Required | Hidden |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------ | -------- | ------ |
-| `vep_assembly`      | The genome assembly to download the cache of. <details><summary>Help</summary><small>This only needs to be supplied when no vep_cache is given</small></details>                                                                                                        | `string`  | GRCh38       |          |        |
-| `vep_cache_version` | The version of the VEP cache to use. <details><summary>Help</summary><small>This version should be present in the folder supplied by `--vep_cache`. This version should be the same as `--vep_version` when no VEP cache was given with `--vep_cache`</small></details> | `integer` | 108          |          |        |
-| `vep_cache`         | The path to the VEP cache folder                                                                                                                                                                                                                                        | `string`  |              |          |        |
-| `vep_version`       | The version of VEP to use                                                                                                                                                                                                                                               | `number`  | 109.3        |          |        |
-| `species`           | The species used for the analysis. Should be all lowercase and spaces should be underscorses.                                                                                                                                                                           | `string`  | homo_sapiens |          |        |
-| `vep_phenotypes`    | Use the Phenotypes VEP plugin <details><summary>Help</summary><small>This requires `--phenotypes` and `--phenotypes_tbi`. </small></details>                                                                                                                            | `boolean` |              |          |        |
-| `phenotypes`        | Path to the phenotypes GFF file                                                                                                                                                                                                                                         | `string`  |              |          |        |
-| `phenotypes_tbi`    | Path to the phenotypes GFF index file                                                                                                                                                                                                                                   | `string`  |              |          |        |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `vep_assembly` | The genome assembly to download the cache of. <details><summary>Help</summary><small>This only needs to be supplied when no vep_cache is given</small></details>| `string` | GRCh38 |  |  |
+| `vep_cache_version` | The version of the VEP cache to use. <details><summary>Help</summary><small>This version should be present in the folder supplied by `--vep_cache`. This version should be the same as `--vep_version` when no VEP cache was given with `--vep_cache`</small></details>| `integer` | 108 |  |  |
+| `vep_cache` | The path to the VEP cache folder | `string` |  |  |  |
+| `vep_version` | The version of VEP to use | `number` | 109.3 |  |  |
+| `species` | The species used for the analysis. Should be all lowercase and spaces should be underscorses. | `string` | homo_sapiens |  |  |
+| `vep_phenotypes` | Use the Phenotypes VEP plugin <details><summary>Help</summary><small>This requires `--phenotypes` and `--phenotypes_tbi`. </small></details>| `boolean` |  |  |  |
+| `phenotypes` | Path to the phenotypes GFF file | `string` |  |  |  |
+| `phenotypes_tbi` | Path to the phenotypes GFF index file | `string` |  |  |  |
 
 ## AnnotSV options
 
 Options specific to the execution of AnnotSV
 
-| Parameter                  | Description                                                                                                                                                                                                             | Type     | Default           | Required | Hidden |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------- | -------- | ------ |
-| `annotsv_annotations`      | The full path to the AnnotSV annotations folder. This can be a tarzipped folder. When --annotate is set to true and this isn't given, the annotations will be downloaded automatically (this is not recommended though) | `string` |                   |          |        |
-| `annotsv_candidate_genes`  | The full path the candidate genes file for AnnotSV                                                                                                                                                                      | `string` |                   |          |        |
-| `annotsv_gene_transcripts` | The full path to the gene transcripts file for AnnotSV                                                                                                                                                                  | `string` |                   |          |        |
-| `annotsv_file_name`        | The default name of the AnnotSV VCFs                                                                                                                                                                                    | `string` | annotsv_annotated |          | True   |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `annotsv_annotations` | The full path to the AnnotSV annotations folder. This can be a tarzipped folder. When --annotate is set to true and this isn't given, the annotations will be downloaded automatically (this is not recommended though) | `string` |  |  |  |
+| `annotsv_candidate_genes` | The full path the candidate genes file for AnnotSV | `string` |  |  |  |
+| `annotsv_gene_transcripts` | The full path to the gene transcripts file for AnnotSV | `string` |  |  |  |
+| `annotsv_file_name` | The default name of the AnnotSV VCFs | `string` | annotsv_annotated |  | True |
 
 ## VCFanno options
 
 Options for the execution of AnnotSV
 
-| Parameter           | Description                                                                                                                                                                                  | Type     | Default | Required | Hidden |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- | -------- | ------ |
-| `vcfanno_toml`      | The full path to the AnnotSV config TOML file. This file will be used to dynamically overwrite default configs for this pipeline run                                                         | `string` |         |          |        |
-| `vcfanno_lua`       | The full path to a lua script for VCFanno                                                                                                                                                    | `string` |         |          |        |
-| `vcfanno_resources` | A comma-delimited list of files referenced in the VCFanno config. This can contain glob patterns as well. Place all filenames together between double qoutes to not cause any irregularities | `string` |         |          |        |
+| Parameter | Description | Type | Default | Required | Hidden |
+|-----------|-----------|-----------|-----------|-----------|-----------|
+| `vcfanno_toml` | The full path to the AnnotSV config TOML file. This file will be used to dynamically overwrite default configs for this pipeline run | `string` |  |  |  |
+| `vcfanno_lua` | The full path to a lua script for VCFanno | `string` |  |  |  |
+| `vcfanno_resources` | A comma-delimited list of files referenced in the VCFanno config. This can contain glob patterns as well. Place all filenames together between double qoutes to not cause any irregularities | `string` |  |  |  |

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -151,6 +151,6 @@ Options for the execution of AnnotSV
 
 | Parameter | Description | Type | Default | Required | Hidden |
 |-----------|-----------|-----------|-----------|-----------|-----------|
-| `vcfanno_toml` | The full path to the AnnotSV config TOML file. This file will be used to dynamically overwrite default configs for this pipeline run | `string` |  |  |  |
+| `vcfanno_toml` | The full path to the VCFanno config TOML file. This file will be used to dynamically overwrite default configs for this pipeline run | `string` |  |  |  |
 | `vcfanno_lua` | The full path to a lua script for VCFanno | `string` |  |  |  |
 | `vcfanno_resources` | A comma-delimited list of files referenced in the VCFanno config. This can contain glob patterns as well. Place all filenames together between double qoutes to not cause any irregularities | `string` |  |  |  |

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -534,7 +534,7 @@
             "properties": {
                 "vcfanno_toml": {
                     "type": "string",
-                    "description": "The full path to the AnnotSV config TOML file. This file will be used to dynamically overwrite default configs for this pipeline run",
+                    "description": "The full path to the VCFanno config TOML file. This file will be used to dynamically overwrite default configs for this pipeline run",
                     "exists": true,
                     "pattern": "^\\S+\\.toml$",
                     "format": "file-path",


### PR DESCRIPTION
Extended the output documentation + made a few changes to modules.config to 
1. prevent double outputs in case --out_callers is used
2. output unique files names depending on the directory and annotation.

